### PR TITLE
jf poly - add trigger mode and voice allocation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This mod adds eight voice targets:
 
 * 1x unison voice. Uses all the Just Friends outputs to produce a detuned unison super-waveform. Adjustable detune.
 
-* 1x poly voice. Uses the internal Just Friends voice allocation. Does not have any parameters.
+* 1x poly voice. Uses the internal Just Friends voice allocation or alternative allocation modes. Has three params:
+    * **trigger mode** controls whether a note will be released. gate mode will trigger a release on note off, trigger mode will not (same as how jf works in transient mode).
+    * **alloc mode** has three options:
+        * `jf` uses the just friends internal voice allocation (ii.jf.play_note), always using all six voices.
+        * `rotate` will rotate between voices, within the range from 1 to `voice count`.
+        * `random` will randomly select voices, within the range from 1 to `voice count`.
+    * **voice count** allows dynamically changing the number of voices used in rotate and random allocation modes.
 
 You can use as many different mono voices at once as you like. I will not be responsible for trying to use mono voices and other voices at the same time, or trying to use unison and poly at the same time. Seems like a silly idea.

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -207,8 +207,28 @@ end
 
 local function add_poly_player()
     local player = {
+        voice_count = 6,
     }
 
+    function player:add_params()
+        local alloc_modes = { "jf", "rotate", "random" }
+        local trigger_modes = { "gate", "trigger" }
+
+        params:add_group("nb_jf_poly", "jf poly", 3)
+        params:add_option("nb_jf_poly_trigger_mode", "trigger mode", trigger_modes, 1)
+        params:add_option("nb_jf_poly_alloc_mode", "voice mode", alloc_modes, 1)
+        params:add_number("nb_jf_poly_voice_count", "voice count", 1, 6, 6, function(p)
+            local alloc_mode = alloc_modes[params:get("nb_jf_poly_alloc_mode")]
+            return alloc_mode == "jf" and 6 or p.value
+        end)
+        params:set_action("nb_jf_poly_voice_count", function(value)
+            local alloc_mode = alloc_modes[params:get("nb_jf_poly_alloc_mode")]
+            if alloc_mode ~= "jf" then
+                self.voice_count = value
+            end
+        end)
+        params:hide("nb_jf_poly")
+    end
     function player:note_on(note, vel)
         local v8 = (note - 60)/12
         local v_vel =  vel^(3/2) * 5
@@ -236,6 +256,8 @@ local function add_poly_player()
 
     function player:delayed_active()
         crow.ii.jf.mode(1)
+        params:show("nb_jf_poly")
+        _menu.rebuild_params()
     end
 
     note_players["jf poly"] = player

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -85,7 +85,7 @@ local function add_mono_player(idx)
                 local elapsed = 0
                 while elapsed < slew do
                     elapsed = elapsed + JF_I2C_FREQ
-                    if elapsed > slew then 
+                    if elapsed > slew then
                         elapsed = slew
                     end
                     self.cur_v8 = (elapsed/slew)*player.v8 + (1 - elapsed/slew)*player.old_v8
@@ -140,7 +140,7 @@ local function add_mono_player(idx)
         end
         params:hide("nb_jf_n_"..idx)
         _menu.rebuild_params()
-    end    
+    end
 
     note_players["jf n "..idx] = player
 end
@@ -157,7 +157,7 @@ local function add_unison_player()
     end
 
     function player:note_on(note, vel)
-        self.count = self.count + 1        
+        self.count = self.count + 1
         self.v8 = (note - 60) / 12
         local v_vel = vel * 5
         local detune = params:get("nb_jf_unison_detune")
@@ -200,7 +200,7 @@ local function add_unison_player()
         end
         params:hide("nb_jf_unison")
         _menu.rebuild_params()
-    end    
+    end
 
     note_players["jf unison"] = player
 end


### PR DESCRIPTION
this introduces three new parameters for jf poly mode.

**trigger mode** dictates whether a note will be released, with `gate` mode retaining the existing behaviour, and `trigger` mode only triggering the note without releasing it (same as how jf works in transient mode).

**alloc mode** introduces three different modes of voice allocation:
- `jf` uses the just friends internal voice allocation (`ii.jf.play_note`), always using all six voices
- `rotate` will rotate between voices, within the range from 1 to `voice_count`
- `random` will randomly select voices, within the range from 1 to `voice_count`

**voice count** allows dynamically changing the number of voices used in `rotate` and `random` allocation modes. i chose not to use the norns internal voice lib, because afaik it does not allow this value to be dynamically changed, instead being set on instantiation.

the default settings for these three params match the existing behaviour of `nb_jf`. 

i introduced **trigger mode**, as i prefer to use jf in transient mode, and it will distribute the notes across all six voices if they are not released. 

i also like to be able to assign **voice count** to a midi knob and use it as a performance parameter, reducing the number of voices when jf is playing lower/longer notes, and adding voices as i go into a higher, pluckier space. unfortunately jf does not support dynamically changing the number of voices out of the box, hence the introduction of the alternative **alloc modes**. 
